### PR TITLE
setup.py: update license trove classifier for MIT license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'Environment :: Console',
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',
-        'License :: OSI Approved :: Apache Software License',
+        'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',


### PR DESCRIPTION
Update the trove classifier metadata for this package to indicate that it is available under the MIT license. The Apache license appears to be a copy-and-paste from elsewhere that does not apply here.